### PR TITLE
Added scene looping and autoplay toggles to UI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ if(currentOS.isMacOsX) {
 }
 // If you need to set the sketchbook location manually, uncomment out the following
 // line and set sketchbookLocation to the correct location
-sketchbookLocation = "C:/Users/danie/OneDrive/Documentos/Processing"
+// sketchbookLocation = "$userHome/Documents/Processing"
 
 
 // Repositories where dependencies will be fetched from.

--- a/src/main/java/paletai/mapping/Project.java
+++ b/src/main/java/paletai/mapping/Project.java
@@ -110,6 +110,11 @@ public class Project {
     /** Whether spacebar loops back from the last scene to the first */
     private boolean loopScenes = false;
 
+    /** Autoplay state and configuration */
+    private boolean autoPlay = false;
+    private float autoPlayDelay = 5.0f; // seconds between scene advances
+    private int autoPlayLastTime = 0;   // millis() timestamp of last advance
+
     /** Available content generators discovered through reflection */
     private ArrayList<LunaContentGenerator> availableGenerators;
 
@@ -947,6 +952,58 @@ public class Project {
 	        }
 	    });
 
+	    // ---- Autoplay toggle ----
+	    Toggle autoPlayToggle = cp5.addToggle("Autoplay")
+	        .setPosition(r + 180, r)
+	        .setSize(40, screenButtonsArea)
+	        .setCaptionLabel("Auto")
+	        .setValue(autoPlay)
+	        .setGroup(sceneList);
+
+	    autoPlayToggle.getCaptionLabel()
+	        .setFont(myFont)
+	        .align(ControlP5.CENTER, ControlP5.CENTER);
+	    autoPlayToggle.setColorBackground(mainApplet.color(80, 60, 120));
+	    autoPlayToggle.setColorForeground(mainApplet.color(110, 90, 160));
+	    autoPlayToggle.setColorActive(mainApplet.color(150, 100, 220));
+	    autoPlayToggle.setColorLabel(mainApplet.color(255));
+
+	    autoPlayToggle.addCallback(new CallbackListener() {
+	        public void controlEvent(CallbackEvent event) {
+	            if (event.getAction() == ControlP5.ACTION_RELEASE) {
+	                autoPlay = autoPlayToggle.getState();
+	                autoPlayLastTime = mainApplet.millis(); // reset timer on toggle
+	            }
+	        }
+	    });
+
+	    // ---- Autoplay delay numberbox ----
+	    Numberbox delayBox = cp5.addNumberbox("Delay (s)")
+	        .setPosition(r + 230, r)
+	        .setSize(50, screenButtonsArea)
+	        .setValue(autoPlayDelay)
+	        .setMin(1)
+	        .setMax(60)
+	        .setScrollSensitivity(0.1f)
+	        .setGroup(sceneList);
+
+	    delayBox.getCaptionLabel().hide();
+	    delayBox.getValueLabel()
+	        .setFont(myFont)
+	        .align(ControlP5.CENTER, ControlP5.CENTER);
+	    delayBox.setColorBackground(mainApplet.color(50));
+	    delayBox.setColorForeground(mainApplet.color(80));
+	    delayBox.setColorActive(mainApplet.color(110));
+	    delayBox.setColorLabel(mainApplet.color(255));
+
+	    delayBox.addCallback(new CallbackListener() {
+	        public void controlEvent(CallbackEvent event) {
+	            if (event.getAction() == ControlP5.ACTION_BROADCAST) {
+	                autoPlayDelay = delayBox.getValue();
+	            }
+	        }
+	    });
+
 	    // ---- Scene selector (radio button) ----
 	    if (sceneRadio != null) sceneRadio.remove();
 
@@ -1210,6 +1267,17 @@ public class Project {
 			scenes.get(currentScene).render();
 		}
 
+		// Autoplay: advance scene when delay has elapsed
+		if (autoPlay && !isTransitioning) {
+			if (mainApplet.millis() - autoPlayLastTime >= autoPlayDelay * 1000) {
+				int target = currentScene + 1;
+				if (target >= scenes.size() && loopScenes) {
+					target = 0;
+				}
+				startTransition(target);
+			}
+		}
+
 		// Update screens with appropriate media list based on transition state
 		if (isTransitioning) {
 			// During transition, screens need access to both scenes' media
@@ -1436,6 +1504,7 @@ public class Project {
 		nextScene = -1;
 		isTransitioning = false;
 		transitionProgress = 0;
+		autoPlayLastTime = mainApplet.millis(); // reset autoplay timer from end of transition
 
 		sceneRadio.activate(currentScene);
 	}

--- a/src/main/java/paletai/mapping/Project.java
+++ b/src/main/java/paletai/mapping/Project.java
@@ -107,6 +107,9 @@ public class Project {
     private int transitionDuration = 2000; // 2 second transition
     private float transitionProgress = 0;
 
+    /** Whether spacebar loops back from the last scene to the first */
+    private boolean loopScenes = false;
+
     /** Available content generators discovered through reflection */
     private ArrayList<LunaContentGenerator> availableGenerators;
 
@@ -920,6 +923,30 @@ public class Project {
 	        }
 	    });
 
+	    // ---- Loop toggle button ----
+	    Toggle loopToggle = cp5.addToggle("Loop Scenes")
+	        .setPosition(r + 120, r)
+	        .setSize(40, screenButtonsArea)
+	        .setCaptionLabel("Loop")
+	        .setValue(loopScenes)
+	        .setGroup(sceneList);
+
+	    loopToggle.getCaptionLabel()
+	        .setFont(myFont)
+	        .align(ControlP5.CENTER, ControlP5.CENTER);
+	    loopToggle.setColorBackground(mainApplet.color(60, 60, 120));
+	    loopToggle.setColorForeground(mainApplet.color(90, 90, 160));
+	    loopToggle.setColorActive(mainApplet.color(100, 100, 220));
+	    loopToggle.setColorLabel(mainApplet.color(255));
+
+	    loopToggle.addCallback(new CallbackListener() {
+	        public void controlEvent(CallbackEvent event) {
+	            if (event.getAction() == ControlP5.ACTION_RELEASE) {
+	                loopScenes = loopToggle.getState();
+	            }
+	        }
+	    });
+
 	    // ---- Scene selector (radio button) ----
 	    if (sceneRadio != null) sceneRadio.remove();
 
@@ -1361,12 +1388,11 @@ public class Project {
 	public void keyreleased(char k, int kc) {
 		saveToFile();
 		if (k == ' ' && !isTransitioning) {
-//			sceneRadio.deactivate(currentScene);
-//			currentScene = PApplet.constrain(currentScene+1,0,scenes.size()-1);
-//			sceneRadio.activate(currentScene);
-//			selectScene(currentScene);
-			startTransition(currentScene + 1);
-			//PApplet.println("Next scene : currentScene + 1");
+			int target = currentScene + 1;
+			if (target >= scenes.size() && loopScenes) {
+				target = 0;
+			}
+			startTransition(target);
 		}
 	}
 


### PR DESCRIPTION
Added a 'Loop' toggle in the UI to activate a function that loops from the last scene back to the first when the user advances the scene by pressing the space bar. Also added an 'Auto' toggle enabling autoplay with a user configurable delay in seconds (1-60). The delay currently excludes the time taken for transitions so a 5-second delay means the scene is fully visible for 5 seconds after the cross-fade completes, rather than 5 seconds including the fade.

<img width="449" height="88" alt="575014385-64a53827-9173-4073-bd99-cbd01648a88b" src="https://github.com/user-attachments/assets/091448ef-0019-4d3d-8c70-816dde28bd0e" />
